### PR TITLE
Add migration for removing column 'user_id' from Cranes

### DIFF
--- a/db/migrate/20230304184100_remove_user_id_from_crane.rb
+++ b/db/migrate/20230304184100_remove_user_id_from_crane.rb
@@ -1,0 +1,5 @@
+class RemoveUserIdFromCrane < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :cranes, :user_id, :integer, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_28_221153) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_04_184100) do
   create_table "cranes", force: :cascade do |t|
     t.string "status"
     t.date "registration_date"
     t.string "serial_number"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "user_id"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Because the name of the company of the User will be in the name of the Crane we will have to remove the column 'user_id' from the 'Cranes' table.