### PR TITLE
Delete unnecessary migrations

### DIFF
--- a/db/migrate/20230128221153_add_user_id_to_crane.rb
+++ b/db/migrate/20230128221153_add_user_id_to_crane.rb
@@ -1,5 +1,0 @@
-class AddUserIdToCrane < ActiveRecord::Migration[7.0]
-  def change
-    add_column :cranes, :user_id, :integer, null: false
-  end
-end

--- a/db/migrate/20230304184100_remove_user_id_from_crane.rb
+++ b/db/migrate/20230304184100_remove_user_id_from_crane.rb
@@ -1,5 +1,0 @@
-class RemoveUserIdFromCrane < ActiveRecord::Migration[7.0]
-  def change
-    remove_column :cranes, :user_id, :integer, null: false
-  end
-end


### PR DESCRIPTION
Delete the unnecessary migrations for the column 'user_id' of the 'Cranes' table