### PR TITLE
Add logic for Companies to view their managed Cranes

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -22,8 +22,11 @@ class CompaniesController < ApplicationController
   end
 
   def view_contractors
-    # Display the contractors for the current company
-    @contractors = Current.user[:contractors]
+  end
+
+  def view_contractor_cranes
+    @user = User.find_by(company_number: params[:contractor_number])
+    @cranes = Crane.where("registration_number LIKE ?", "#{params[:contractor_number]}%")
   end
 
   def edit_contractors
@@ -43,7 +46,6 @@ class CompaniesController < ApplicationController
 
 
   def update_contractors
-    # Update the contractors for the current company
     if @company.save
       redirect_to company_check_contractors_path, notice: 'Contractors updated successfully!'
     else
@@ -62,7 +64,6 @@ class CompaniesController < ApplicationController
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
     def set_company
       @company = Company.find(Current.user[:id])
     end

--- a/app/views/companies/_company.html.erb
+++ b/app/views/companies/_company.html.erb
@@ -1,21 +1,21 @@
 <div id="<%= dom_id company %>">
   <p>
-    <strong>Name:</strong>
+    <strong>Име:</strong>
     <%= company.name %>
   </p>
 
   <p>
-    <strong>Uic:</strong>
+    <strong>ЕИК:</strong>
     <%= company.uic %>
   </p>
 
   <p>
-    <strong>Email:</strong>
+    <strong>Имейл:</strong>
     <%= company.email %>
   </p>
 
   <p>
-    <strong>Address:</strong>
+    <strong>Адрес:</strong>
     <%= company.address %>
   </p>
 

--- a/app/views/companies/view_contractor_cranes.html.erb
+++ b/app/views/companies/view_contractor_cranes.html.erb
@@ -1,0 +1,41 @@
+<h1>Съоръжения, поддържани от орган за технически надзор <%= @user[:name] %></h1>
+
+<br>
+
+<% if flash[:alert] %>
+  <div class="alert alert-danger"><%= flash[:alert] %></div>
+<% end %>
+
+<% if flash[:notice] %>
+  <div class="alert alert-success"><%= flash[:notice] %></div>
+<% end %>
+
+<table>
+  <thead>
+    <tr>
+      <th>Регистрационен номер</th>
+      <th>Статус</th>
+      <th>Тип</th>
+      <th>Заводски номер</th>
+      <th>Товароподемност</th>
+      <th>Местонахождение</th>
+      <th>Дата на следваща проверка</th>
+      <th colspan="6"></th>
+    </tr>
+  </thead>
+  <tbody>
+      <% @cranes.each do |crane| %>
+        <tr>
+          <td><%= crane.registration_number %></td>
+          <td><%= crane.status %></td>
+          <td><%= crane.crane_type %></td>
+          <td><%= crane.serial_number %></td>
+          <td><%= crane.load_capacity %></td>
+          <td><%= crane.manufacturer %></td>
+          <td><%= crane.next_check_date %></td>
+        </tr>
+      <% end %>
+  </tbody>
+</table>
+
+<%= link_to "Обратно към органи за технически надзор", company_check_contractors_path %>

--- a/app/views/companies/view_contractors.html.erb
+++ b/app/views/companies/view_contractors.html.erb
@@ -26,6 +26,7 @@
             <td><%= contractor[:name] %></td>
             <td><%= contractor[:email] %></td>
             <td><%= contractor[:company_number] %></td>
+            <td><%= link_to "Покажи съоръжения", company_check_contractor_cranes_path(:contractor_number => contractor_number) %></td>
             <td><%= button_to "Премахване", destroy_contractors_path(contractor_number: contractor_number), method: :delete, data: { confirm: "Сигурни ли сте, че искате да премахнете #{contractor[:name]} от вашите органи за технически надзор?" } %></td>
         </tr>
       <% end %>


### PR DESCRIPTION
A Company should be able to view the Cranes which a given contractor is managing. The Company however should not be able to delete these Cranes, only the contractor is able to delete it since he is the one who is managing it.