### PR TITLE
Add encrypted file for configuring SMTP settings

### DIFF
--- a/app/controllers/composes_controller.rb
+++ b/app/controllers/composes_controller.rb
@@ -3,7 +3,11 @@ class ComposesController < ApplicationController
     end
 
     def create
-        ComposeMailer.compose(email: params[:email]).deliver_now
-        redirect_to root_path, :flash => { :notice => 'Имейлът е изпратен успешно.' }
+        begin
+            ComposeMailer.compose(email: params[:email]).deliver_now
+            redirect_to root_path, :flash => { :notice => 'Имейлът е изпратен успешно.' }
+        rescue => e
+            redirect_to root_path, :flash => { :alert => 'Имейлът за изпращане не е конфигуриран правилно! Моля, оправете настройките и презаредете сървъра.' }
+        end
     end
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,8 @@
 class ApplicationMailer < ActionMailer::Base
   default from: "from@example.com"
   layout "mailer"
+
+  def smtp_settings
+    Rails.application.config.action_mailer.smtp_settings
+  end
 end

--- a/app/mailers/compose_mailer.rb
+++ b/app/mailers/compose_mailer.rb
@@ -1,11 +1,9 @@
 class ComposeMailer < ApplicationMailer
 
-  # Subject can be set in your I18n file at config/locales/en.yml
-  # with the following lookup:
-  #
-  #   en.password_mailer.reset.subject
-  #
   def compose(email:)
-    mail to: email
+    if Current.user[:email] != smtp_settings[:user_name]
+      raise StandardError
+    end
+    mail from: smtp_settings[:user_name], to: email
   end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Добре дошли в системата!</h1>
 <% unless flash[:notice].nil? %>
-    <div class="notice"><%= flash[:notice] %></div>
+    <div class="alert alert-success"><%= flash[:notice] %></div>
 <% end %>
 <% unless flash[:alert].nil? %>
-    <div class="alert alert-danger" role="alert"><%= flash[:alert] %></div>
+    <div class="alert alert-danger"><%= flash[:alert] %></div>
 <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,13 +48,9 @@ Rails.application.configure do
 
   config.action_mailer.raise_delivery_errors = true
 
-  config.action_mailer.smtp_settings = {
-   :address => "smtp.gmail.com",
-   :port => 587,
-   :user_name => 'zaedinden1@gmail.com',
-   :password => 'dzhllmhmpblvajwu',
-   :authentication => 'plain'
-  }
+  smtp_settings = YAML.load_file(Rails.root.join("config", "smtp_settings.yaml"))
+
+  config.action_mailer.smtp_settings = smtp_settings[<email_goes_here>].deep_symbolize_keys!
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/smtp_settings.enc
+++ b/config/smtp_settings.enc
@@ -1,0 +1,2 @@
+Salted__'©Ô]E¤º+Ëû!Ý¨®ÐgÐgH„tœì½OÚØyÄÿ÷b©NÏ1!æŸ5àQßÞÍ?òÏ8´“$—è›†‚?Çiø©>1	$>Ð>#ð¹ÒÁW`œc‚)Ð×8›Á…"®u“F(IgžŽó)·ò*¼Í–¸ÅÖòžÌb'5dï6¨ÿT®÷¯á9^F-né½êÜp¹ÃRzmåÝÈ›òÓ§h€
+!0T¶³ŽFq	ËÅYˆgFú‚0>ìßÐóæy¨6~ÕCjX¼[A?šì«÷®ÃÀî#õqŽA

--- a/config/smtp_settings.yaml
+++ b/config/smtp_settings.yaml
@@ -1,0 +1,8 @@
+testotn1@gmail.com:
+  address: 'smtp.gmail.com'
+  port: 587
+  user_name: 'testotn1@gmail.com'
+  password: 'xqvsdvdxhuorccfp'
+  authentication: 'plain'
+  enable_starttls_auto: true
+  openssl_verify_mode: 'none'


### PR DESCRIPTION
A User or a Company must send emails through the system. The settings for SMTP require not only the user email but a password generated for the application. A user's password should not be exposed directly. Instead the SMTP settings should be loaded from an smtp_settings.yaml file, encrypted with AES. When a User or a Company want to add their credentials they will decrypt the smtp_settings.enc file and add their credentials to the .yaml file. They will also need to change the email in the development.rb file.