### PR TITLE
Add new table for SMTP configurations of Users and Companies

### DIFF
--- a/app/controllers/composes_controller.rb
+++ b/app/controllers/composes_controller.rb
@@ -10,7 +10,7 @@ class ComposesController < ApplicationController
             ComposeMailer.compose_user(email: params[:email], message: @message).deliver_now
             redirect_to root_path, :flash => { :notice => 'Имейлът е изпратен успешно.' }
         rescue => e
-            redirect_to root_path, :flash => { :alert => 'Имейлът за изпращане не е конфигуриран правилно! Моля, оправете настройките и презаредете сървъра.' }
+            redirect_to root_path, :flash => { :alert => 'SMTP конфигурациите са грешни! Моля, актуализирайте ги и опитайте отново' }
         end
     end
 
@@ -26,7 +26,7 @@ class ComposesController < ApplicationController
             ).deliver_now
             redirect_to root_path, :flash => { :notice => 'Имейлът е изпратен успешно.' }
         rescue => e
-            redirect_to root_path, :flash => { :alert => 'Имейлът за изпращане не е конфигуриран правилно! Моля, оправете настройките и презаредете сървъра.' }
+            redirect_to root_path, :flash => { :alert => 'SMTP конфигурациите са грешни! Моля, актуализирайте ги и опитайте отново' }
         end
     end
 

--- a/app/controllers/smtp_settings_controller.rb
+++ b/app/controllers/smtp_settings_controller.rb
@@ -1,0 +1,36 @@
+class SmtpSettingsController < ApplicationController
+    before_action :require_user_logged_in!
+
+    def edit
+        if Current.user.smtp_settings.nil?
+            Current.user.smtp_settings = SmtpSetting.new(
+              address: 'smtp.gmail.com',
+              port: 587,
+              user_name: Current.user[:email],
+              authentication: 'plain',
+              enable_starttls_auto: true,
+              openssl_verify_mode: 'none'
+            )
+            Current.user.smtp_settings.save
+        end
+        @smtp_settings = Current.user.smtp_settings
+    end
+
+    def update
+        @smtp_settings = Current.user.smtp_settings || Current.user.build_smtp_settings
+        if @smtp_settings.update(smtp_settings_params)
+          redirect_to root_path, notice: 'SMTP настройките бяха ъпдейтнати успешно.'
+        else
+          render :edit
+        end
+    end
+
+    def smtp_settings_params
+        params.require(:smtp_setting).permit(:password).tap do |settings|
+            key = ENV['SMTP_PASSWORD_ENCRYPTION_KEY']
+            crypt = ActiveSupport::MessageEncryptor.new(key)
+            encrypted_password = crypt.encrypt_and_sign(settings[:password])
+            settings[:password] = encrypted_password
+        end
+    end
+end

--- a/app/mailers/compose_mailer.rb
+++ b/app/mailers/compose_mailer.rb
@@ -1,20 +1,37 @@
 class ComposeMailer < ApplicationMailer
 
   def compose_user(email:, message:)
-    if Current.user[:email] != smtp_settings[:user_name]
-      raise StandardError
-    end
-    mail from: smtp_settings[:user_name], to: email, subject:'Предстояща проверка' do |format|
+    set_smtp_settings
+
+    mail from: ActionMailer::Base.smtp_settings[:user_name], to: email, subject:'Предстояща проверка' do |format|
       format.text { render plain: message }
     end
   end
 
   def compose_company(email:, subject:, message:)
-    if Current.user[:email] != smtp_settings[:user_name]
-      raise StandardError
-    end
-    mail from: smtp_settings[:user_name], to: email, subject: subject do |format|
+    set_smtp_settings
+
+    mail from: ActionMailer::Base.smtp_settings[:user_name], to: email, subject: subject do |format|
       format.text { render plain: message }
     end
   end
+
+  private
+
+  def set_smtp_settings
+    smtp_settings = Current.user.smtp_settings
+    key = ENV['SMTP_PASSWORD_ENCRYPTION_KEY']
+    crypt = ActiveSupport::MessageEncryptor.new(key)
+    decrypted_password = crypt.decrypt_and_verify(smtp_settings.password)
+    ActionMailer::Base.smtp_settings = {
+      address: smtp_settings.address,
+      port: smtp_settings.port,
+      user_name: smtp_settings.user_name,
+      password: decrypted_password,
+      authentication: smtp_settings.authentication,
+      enable_starttls_auto: smtp_settings.enable_starttls_auto,
+      openssl_verify_mode: smtp_settings.openssl_verify_mode
+    }
+  end
+
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,5 +1,6 @@
 class Company < ApplicationRecord
     has_secure_password
+    has_one :smtp_settings, dependent: :destroy, class_name: "SmtpSetting"
     has_many :company_contractors
     has_many :contractors, through: :company_contractors, source: :user
     

--- a/app/models/smtp_setting.rb
+++ b/app/models/smtp_setting.rb
@@ -1,0 +1,4 @@
+class SmtpSetting < ApplicationRecord
+    belongs_to :user, optional: true, class_name: "User"
+    belongs_to :company, optional: true, class_name: "Company"
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@
 
 class User < ApplicationRecord
     has_secure_password
+    has_one :smtp_settings, dependent: :destroy, class_name: "SmtpSetting"
     has_many :company_contractors
     has_many :company_users, through: :company_contractors, source: :company
 

--- a/app/views/company_contractors/index.html.erb
+++ b/app/views/company_contractors/index.html.erb
@@ -14,7 +14,7 @@
   </thead>
 
   <tbody>
-    <% Current.user.company_contractors.each do |company_contractor| %>
+    <% @company_contractors.each do |company_contractor| %>
       <tr>
         <td><%= company_contractor.company.name %></td>
         <td><%= company_contractor.company.uic %></td>

--- a/app/views/home/_header.html.erb
+++ b/app/views/home/_header.html.erb
@@ -20,12 +20,18 @@
             <li class="nav-item">
                 <%= link_to 'Напиши имейл', compose_user_path, class:"nav-link" %>
             </li>
+            <li class="nav-item">
+                <%= link_to 'Настройка на SMTP', edit_smtp_setting_path(Current.user), class:"nav-link" %>
+            </li>
           <% elsif session[:company_id] %>
             <li class="nav-item">
                 <%= link_to 'Напиши имейл', compose_company_path, class:"nav-link" %>
             </li>
             <li class="nav-item">
                 <%= link_to 'Органи за надзор', company_check_contractors_path, class:"nav-link" %>
+            </li>
+            <li class="nav-item">
+                <%= link_to 'Настройка на SMTP', edit_smtp_setting_path(Current.user), class:"nav-link" %>
             </li>
             <li class="nav-item">
                 <%= link_to 'Информация за възложителя', company_path(Current.user), class:"nav-link" %>

--- a/app/views/smtp_settings/edit.html.erb
+++ b/app/views/smtp_settings/edit.html.erb
@@ -1,0 +1,11 @@
+<h1>Настройки на SMTP </h1>
+
+<%= form_with(model: @smtp_settings, url: smtp_setting_path(Current.user), method: :patch) do |f| %>
+  <div>
+    <%= f.label 'Парола' %>
+    <%= f.password_field :password %>
+  </div>
+  <div>
+    <%= f.submit 'Запази' %>
+  </div>
+<% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,10 +48,6 @@ Rails.application.configure do
 
   config.action_mailer.raise_delivery_errors = true
 
-  smtp_settings = YAML.load_file(Rails.root.join("config", "smtp_settings.yaml"))
-
-  config.action_mailer.smtp_settings = smtp_settings[<email_goes_here>].deep_symbolize_keys!
-
   # needed for months:
   config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '*.{rb,yml,yaml}').to_s]
   config.i18n.default_locale = :bg

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   resources :companies
   resources :cranes
+  resources :smtp_settings, only: [:edit, :update]
   
   root 'home#index'
 

--- a/db/migrate/20230423150500_create_smtp_settings.rb
+++ b/db/migrate/20230423150500_create_smtp_settings.rb
@@ -1,0 +1,16 @@
+class CreateSmtpSettings < ActiveRecord::Migration[7.0]
+  def change
+    create_table :smtp_settings do |t|
+      t.references :user, foreign_key: true
+      t.references :company, foreign_key: true
+      t.string :address
+      t.integer :port
+      t.string :user_name
+      t.string :password
+      t.string :authentication
+      t.boolean :enable_starttls_auto
+      t.string :openssl_verify_mode
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_22_104001) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_23_150500) do
   create_table "companies", force: :cascade do |t|
     t.string "email", null: false
     t.string "name"
@@ -53,6 +53,22 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_22_104001) do
     t.text "notes"
   end
 
+  create_table "smtp_settings", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "company_id"
+    t.string "address"
+    t.integer "port"
+    t.string "user_name"
+    t.string "password"
+    t.string "authentication"
+    t.boolean "enable_starttls_auto"
+    t.string "openssl_verify_mode"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["company_id"], name: "index_smtp_settings_on_company_id"
+    t.index ["user_id"], name: "index_smtp_settings_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
     t.string "password_digest"
@@ -64,4 +80,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_22_104001) do
 
   add_foreign_key "company_contractors", "companies"
   add_foreign_key "company_contractors", "users"
+  add_foreign_key "smtp_settings", "companies"
+  add_foreign_key "smtp_settings", "users"
 end


### PR DESCRIPTION
The initial idea for the application was to fetch the SMTP configurations from a .yaml file which first has to be decrypted and then the proper email should be inserted in the development.rb file. This approach is bad because the application will be hosted on a server and:
1. It's presumed the users won't have access to the code of the server
2. It limits the user of the application to insert one specific email even if they could edit the code of the server.

A better approach is to create a new table to set up a one-to-one relationship with a User/Company. This table will take care of the SMTP settings for each user but since we will be using SMTP only the password will be edited. We are using a new environment variable 'SMTP_PASSWORD_ENCRYPTION_KEY' and ActiveSupport::MessageEncryptor to encrypt the password when editing and storing it in the DB and decrypting it when sending an email.

The env variable must be requested by the server host and added before the deployment of the application.