### PR TITLE
Update the column 'name' of Users to not be nullable

### DIFF
--- a/db/migrate/20230515180000_update_users_change_name_nullability.rb
+++ b/db/migrate/20230515180000_update_users_change_name_nullability.rb
@@ -1,0 +1,5 @@
+class UpdateUsersChangeNameNullability < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :users, :name, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_07_101001) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_15_180000) do
   create_table "companies", force: :cascade do |t|
     t.string "email", null: false
     t.string "name"
@@ -88,7 +88,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_07_101001) do
     t.integer "company_number", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "name"
+    t.string "name", null: false
   end
 
   add_foreign_key "company_contractors", "companies"


### PR DESCRIPTION
A User's name column is the name of his own firm. It must not be null since it must represent him.