### PR TITLE
Update the columns 'name', 'uic' and 'address' of Companies to not be nullable

### DIFF
--- a/db/migrate/20230515181000_update_companies_change_name_nullability.rb
+++ b/db/migrate/20230515181000_update_companies_change_name_nullability.rb
@@ -1,0 +1,7 @@
+class UpdateCompaniesChangeNameNullability < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :companies, :name, false
+    change_column_null :companies, :uic, false
+    change_column_null :companies, :address, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_15_180000) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_15_181000) do
   create_table "companies", force: :cascade do |t|
     t.string "email", null: false
-    t.string "name"
+    t.string "name", null: false
     t.string "password_digest"
-    t.integer "uic"
-    t.string "address"
+    t.integer "uic", null: false
+    t.string "address", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
A Company's 'name', 'uic' and 'address' columns must not be null since these fields are a part of the full Company representation.