### PR TITLE
Fix JS timezone issues

### DIFF
--- a/app/assets/javascripts/helper_functions.js
+++ b/app/assets/javascripts/helper_functions.js
@@ -61,15 +61,23 @@ $(document).ready(function() {
     if(age > 10)
     {
       lastCheckDateValue.setFullYear(lastCheckDateValue.getFullYear() + 1);
-      lastCheckDateValue.setMonth(lastCheckDateValue.getMonth() + 1, 0);
-      var dateString = lastCheckDateValue.toISOString().substr(0, 10);
+      lastCheckDateValue.setMonth(lastCheckDateValue.getMonth() + 1, 1);
+      lastCheckDateValue.setDate(0);
+      var year = lastCheckDateValue.getFullYear();
+      var month = lastCheckDateValue.getMonth() + 1;
+      var day = lastCheckDateValue.getDate();
+      var dateString = year + '-' + month.toString().padStart(2, '0') + '-' + day.toString().padStart(2, '0');
       $nextCheckDateField.val(dateString);
     }
     else
     {
       lastCheckDateValue.setFullYear(lastCheckDateValue.getFullYear() + 2);
-      lastCheckDateValue.setMonth(lastCheckDateValue.getMonth() + 1, 0);
-      var dateString = lastCheckDateValue.toISOString().substr(0, 10);
+      lastCheckDateValue.setMonth(lastCheckDateValue.getMonth() + 1, 1);
+      lastCheckDateValue.setDate(0);
+      var year = lastCheckDateValue.getFullYear();
+      var month = lastCheckDateValue.getMonth() + 1;
+      var day = lastCheckDateValue.getDate();
+      var dateString = year + '-' + month.toString().padStart(2, '0') + '-' + day.toString().padStart(2, '0');
       $nextCheckDateField.val(dateString);
     }
     

--- a/app/views/composes/new_user_email.html.erb
+++ b/app/views/composes/new_user_email.html.erb
@@ -52,6 +52,6 @@
 <%= form_with url: compose_user_path do |form| %>
     <%= form.hidden_field :company_email, value: @company_email %>
     <div class='mb-3'>
-        <%= form.submit 'Изпратете имейл', class: 'btn btn-primary' %>
+        <%= form.submit 'Изпрати', class: 'btn btn-primary' %>
     </div>
 <% end %>


### PR DESCRIPTION
After running the code on another VM it turned out the JS code wasn't setting the next check date properly because of different timezone settings. This is because the JS 'Date' object's behavior can be influenced by the local timeone settings of the machine running the code. The toISOString() method returns a string representation of the date in UTC format, but when constructing the Date object, it takes into account the local timezone. 

To ensure consistent behavior and obtain the last day of the month, we have updated the code. With the current changes, we explicitly set the day to 1 using setMonth(lastCheckDateValue.getMonth() + 1, 1). This moves the date to the first day of the next month. Then, we subtract 1 day using setDate(0) to set it to the last day of the current month.

After obtaining the year, month, and day values, the dateString is constructed in the format 'YYYY-MM-DD' using the padStart() function to ensure zero-padding for single-digit month and day values.